### PR TITLE
Add basic ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Biome
+        uses: biomejs/setup-biome@v2
+        with:
+          version: latest
+      - name: Run Biome
+        run: biome ci .


### PR DESCRIPTION
Adds a basic CI workflow to run linter and formatter based on this [starter](https://github.com/actions/starter-workflows/blob/main/ci/node.js.yml) and [biome docs](https://biomejs.dev/recipes/continuous-integration/)