### PR TITLE
Remove unnecessary `yarn check:all` cmd

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,7 +1,3 @@
 enableGlobalCache: true
-
 nodeLinker: node-modules
-
 npmRegistryServer: "https://registry.npmjs.org/"
-
-yarnPath: .yarn/releases/yarn-4.6.0.cjs

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "format": "biome format --write .",
     "lint": "biome lint --write .",
     "check": "biome check --write .",
-    "check:all": "biome check . --no-errors-on-unmatched --files-ignore-unknown=true",
     "postinstall": "husky install",
     "prepare": "husky",
     "lint-staged": "lint-staged"
@@ -29,6 +28,6 @@
   "workspaces": ["./packages/*"],
   "packageManager": "yarn@4.6.0",
   "lint-staged": {
-    "*": "yarn check:all"
+    "*": "yarn check"
   }
 }


### PR DESCRIPTION
Let's default to formatting and linting safe errors on commit, and let CI fail if anything further needs to be resolved.